### PR TITLE
Fix matching flow on Main Page

### DIFF
--- a/frontend/main_page.py
+++ b/frontend/main_page.py
@@ -1,6 +1,6 @@
 # frontend/main_page.py
 import streamlit as st
-from config import config_manager
+from config import config_manager, paths
 from services import file_processing, file_matching
 
 def main_page():
@@ -8,12 +8,10 @@ def main_page():
 
     config = config_manager.load_config()
 
-    full_price_df = file_processing.read_full_price_file(config["full_price_file"])
-    new_items_df = file_processing.read_new_items_file(config["newitems_file"])
-
     for po_filename in config["po_files"]:
-        po_df = file_processing.read_po_file(po_filename)
-        matched_items = file_matching.match_items(po_df, new_items_df, config["po_qty_column"])
+        po_path = paths.UPLOADED_PO_DIR / po_filename
+        new_items_path = paths.NEW_ITEMS_DIR / config["newitems_file"]
+        matched_items = file_matching.match_items(po_path, new_items_path, config["po_qty_column"])
         output_filename = f"matched_{po_filename.replace('.xlsx', '')}.csv"
         file_processing.save_matched_items(matched_items, output_filename)
         st.success(f"Matched items saved to {output_filename}")


### PR DESCRIPTION
## Summary
- update main page to pass file paths into `match_items`

## Testing
- `python -m py_compile frontend/main_page.py services/file_matching.py`

------
https://chatgpt.com/codex/tasks/task_b_687303eed840832d82adc6071dd28b4e