### PR TITLE
Add Start Matching button

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ streamlit run app.py
 
 4. **Process Orders:**
 - Navigate to the Main Page.
-- Click process to generate matched item files.
+- Click **Start Matching** to generate matched item files.
 
 ---

--- a/frontend/main_page.py
+++ b/frontend/main_page.py
@@ -8,10 +8,27 @@ def main_page():
 
     config = config_manager.load_config()
 
-    for po_filename in config["po_files"]:
-        po_path = paths.UPLOADED_PO_DIR / po_filename
-        new_items_path = paths.NEW_ITEMS_DIR / config["newitems_file"]
-        matched_items = file_matching.match_items(po_path, new_items_path, config["po_qty_column"])
-        output_filename = f"matched_{po_filename.replace('.xlsx', '')}.csv"
-        file_processing.save_matched_items(matched_items, output_filename)
-        st.success(f"Matched items saved to {output_filename}")
+    st.subheader("Selected Files")
+
+    new_items_file = config.get("newitems_file")
+    if new_items_file:
+        st.write(f"New Items File: {new_items_file}")
+    else:
+        st.write("No New Items File selected.")
+
+    po_files = config.get("po_files", [])
+    if po_files:
+        st.write("PO Files:")
+        for po in po_files:
+            st.write(f"- {po}")
+    else:
+        st.write("No PO Files selected.")
+
+    if st.button("Start Matching"):
+        for po_filename in po_files:
+            po_path = paths.UPLOADED_PO_DIR / po_filename
+            new_items_path = paths.NEW_ITEMS_DIR / new_items_file
+            matched_items = file_matching.match_items(po_path, new_items_path, config["po_qty_column"])
+            output_filename = f"matched_{po_filename.replace('.xlsx', '')}.csv"
+            file_processing.save_matched_items(matched_items, output_filename)
+            st.success(f"Matched items saved to {output_filename}")


### PR DESCRIPTION
## Summary
- show selected files on the main page
- add **Start Matching** button before processing
- update instructions in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687414dbd26c832d8320d818e004221b