### PR TITLE
Add matched item selection and export

### DIFF
--- a/frontend/main_page.py
+++ b/frontend/main_page.py
@@ -2,6 +2,8 @@
 import streamlit as st
 from config import config_manager, paths
 from services import file_processing, file_matching
+import pandas as pd
+from datetime import datetime
 
 def main_page():
     st.header("Process Orders")
@@ -25,6 +27,7 @@ def main_page():
         st.write("No PO Files selected.")
 
     if st.button("Start Matching"):
+        matched_list = []
         for po_filename in po_files:
             po_path = paths.UPLOADED_PO_DIR / po_filename
             new_items_path = paths.NEW_ITEMS_DIR / new_items_file
@@ -32,3 +35,26 @@ def main_page():
             output_filename = f"matched_{po_filename.replace('.xlsx', '')}.csv"
             file_processing.save_matched_items(matched_items, output_filename)
             st.success(f"Matched items saved to {output_filename}")
+            matched_list.append(matched_items)
+
+        if matched_list:
+            st.session_state["matched_df"] = pd.concat(matched_list, ignore_index=True)
+        else:
+            st.session_state["matched_df"] = pd.DataFrame()
+
+    matched_df = st.session_state.get("matched_df")
+    if isinstance(matched_df, pd.DataFrame) and not matched_df.empty:
+        st.subheader("Matched Items")
+        selected_indices = []
+        for idx, row in matched_df.iterrows():
+            label_parts = [str(row[col]) for col in matched_df.columns[:2]]
+            if st.checkbox(" - ".join(label_parts), key=f"sel_{idx}"):
+                selected_indices.append(idx)
+
+        if st.button("Create new file"):
+            if selected_indices:
+                export_df = matched_df.loc[selected_indices]
+                output_path = file_processing.save_selected_items(export_df)
+                st.success(f"Selected items saved to {output_path.name}")
+            else:
+                st.warning("No items selected.")

--- a/services/file_processing.py
+++ b/services/file_processing.py
@@ -1,6 +1,7 @@
 # services/file_processing.py
 import pandas as pd
 from config import paths
+from datetime import datetime
 
 def list_files_in_directory(directory_path):
     return [f.name for f in directory_path.glob("*.*") if f.is_file()]
@@ -20,5 +21,14 @@ def read_po_file(filename):
 
 def save_matched_items(df, output_filename):
     output_path = paths.NEW_ITEMS_DIR / output_filename
+    df.to_csv(output_path, index=False)
+    return output_path
+
+
+def save_selected_items(df):
+    """Save selected items to a timestamped file in the New Items directory."""
+    timestamp = datetime.now().strftime("%y%m%d_%H%M%S")
+    filename = f"NewItems_{timestamp}.csv"
+    output_path = paths.NEW_ITEMS_DIR / filename
     df.to_csv(output_path, index=False)
     return output_path


### PR DESCRIPTION
## Summary
- show matched items after starting matching
- allow user to select rows with checkboxes and export them
- save selected rows using a timestamped filename

## Testing
- `python -m py_compile frontend/main_page.py services/file_processing.py`

------
https://chatgpt.com/codex/tasks/task_b_687459015964832db63732949a4a8e19