### PR TITLE
Remove unused full price file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Maggys Order App
 
-This Streamlit-based web application helps manage product orders for Maggys by filtering, matching, and processing purchase order (PO) files, new items files, and full price lists.
+This Streamlit-based web application helps manage product orders for Maggys by filtering, matching, and processing purchase order (PO) files and new items files.
 
 ### 📂 Folder Structure Overview
 
@@ -32,7 +32,7 @@ streamlit run app.py
 
 3. **Configure:**
 - Go to the Configuration page.
-- Select the relevant files for Full Price, New Items, and PO Files.
+- Select the relevant files for New Items and PO Files.
 - Set the PO Quantity column name.
 - Save the configuration.
 

--- a/config.json
+++ b/config.json
@@ -1,5 +1,4 @@
 {
-    "full_price_file": "Maggys June Price List.xlsx",
     "newitems_file": "NEW_V09_20240701_152944.csv",
     "po_files": [],
     "po_qty_column": "Sales Products Qty"

--- a/config/config_manager.py
+++ b/config/config_manager.py
@@ -8,12 +8,14 @@ CONFIG_FILE = Path("config.json")
 def load_config():
     if CONFIG_FILE.exists():
         with open(CONFIG_FILE, "r") as f:
-            return json.load(f)
+            config = json.load(f)
+        # Remove legacy key if present
+        config.pop("full_price_file", None)
+        return config
     return {
-        "full_price_file": None,
         "newitems_file": None,
         "po_files": [],
-        "po_qty_column": "Sales Products Qty"
+        "po_qty_column": "Sales Products Qty",
     }
 
 

--- a/frontend/config_page.py
+++ b/frontend/config_page.py
@@ -9,7 +9,6 @@ def config_page():
 
     config = config_manager.load_config()
 
-    full_price_files = file_processing.list_files_in_directory(paths.FULL_PRICE_DIR)
     new_items_files = file_processing.list_files_in_directory(paths.NEW_ITEMS_DIR)
     po_files = file_processing.list_files_in_directory(paths.UPLOADED_PO_DIR)
 
@@ -21,7 +20,6 @@ def config_page():
         st.success(f"File {uploaded_po.name} uploaded successfully!")
         po_files = file_processing.list_files_in_directory(paths.UPLOADED_PO_DIR)
 
-    config["full_price_file"] = st.selectbox("Select Full Price File", full_price_files, index=full_price_files.index(config.get("full_price_file")) if config.get("full_price_file") else 0)
     config["newitems_file"] = st.selectbox("Select New Items File", new_items_files, index=new_items_files.index(config.get("newitems_file")) if config.get("newitems_file") else 0)
     config["po_files"] = st.multiselect("Select PO Files", po_files, default=config.get("po_files", []))
 


### PR DESCRIPTION
## Summary
- remove full price file picker from `config_page`
- strip legacy key handling in `config_manager`
- clean up example `config.json`
- update documentation for new configuration steps

## Testing
- `python3 -m py_compile app.py frontend/config_page.py config/config_manager.py frontend/main_page.py services/file_processing.py frontend/upload_page.py`

------
https://chatgpt.com/codex/tasks/task_b_6876c1a3f00c832da6d2799f9db1dbd8