### PR TITLE
Require PO selection to save configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ streamlit run app.py
 
 3. **Configure:**
 - Go to the Configuration page.
-- Select the relevant files for New Items and PO Files.
+- Select the relevant files for New Items and at least one PO File.
 - Set the PO Quantity column name.
 - Save the configuration.
 

--- a/frontend/config_page.py
+++ b/frontend/config_page.py
@@ -25,6 +25,11 @@ def config_page():
 
     config["po_qty_column"] = st.text_input("PO Quantity Column Name", config.get("po_qty_column", "Sales Products Qty"))
 
-    if st.button("Save Configuration"):
+    if len(po_files) == 0:
+        st.warning("No PO files available. Please upload a PO file before saving.")
+
+    save_disabled = len(po_files) == 0 or len(config.get("po_files", [])) == 0
+
+    if st.button("Save Configuration", disabled=save_disabled):
         config_manager.save_config(config)
         st.success("Configuration Saved!")


### PR DESCRIPTION
## Summary
- prevent saving config when no PO files are selected
- document PO selection requirement in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6876d329fd80832dae3d3a2e5ca31862