### PR TITLE
Add configurable logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ streamlit run app.py
 - Go to the Configuration page.
 - Select the relevant files for New Items and at least one PO File.
 - Set the PO Quantity column name.
+- Enable **Logging On** if you want to store process logs.
 - Save the configuration.
 
 4. **Process Orders:**

--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
     "newitems_file": "NEW_V09_20240701_152944.csv",
     "po_files": [],
-    "po_qty_column": "Sales Products Qty"
+    "po_qty_column": "Sales Products Qty",
+    "logging_on": false
 }

--- a/config/config_manager.py
+++ b/config/config_manager.py
@@ -11,11 +11,14 @@ def load_config():
             config = json.load(f)
         # Remove legacy key if present
         config.pop("full_price_file", None)
+        if "logging_on" not in config:
+            config["logging_on"] = False
         return config
     return {
         "newitems_file": None,
         "po_files": [],
         "po_qty_column": "Sales Products Qty",
+        "logging_on": False,
     }
 
 

--- a/config/paths.py
+++ b/config/paths.py
@@ -6,3 +6,4 @@ BASE_DIR = Path(r"C:/Users/Public/ItemImport")
 FULL_PRICE_DIR = BASE_DIR / "Docs"
 NEW_ITEMS_DIR = BASE_DIR / "New"
 UPLOADED_PO_DIR = BASE_DIR / "UploadedPO"
+LOG_DIR = BASE_DIR / "log"

--- a/frontend/config_page.py
+++ b/frontend/config_page.py
@@ -23,6 +23,8 @@ def config_page():
     config["newitems_file"] = st.selectbox("Select New Items File", new_items_files, index=new_items_files.index(config.get("newitems_file")) if config.get("newitems_file") else 0)
     config["po_files"] = st.multiselect("Select PO Files", po_files, default=config.get("po_files", []))
 
+    config["logging_on"] = st.checkbox("Logging On", value=config.get("logging_on", False))
+
     if po_files and len(config["po_files"]) == 0:
         st.warning("Please select at least one PO file before saving.")
 

--- a/services/file_matching.py
+++ b/services/file_matching.py
@@ -1,13 +1,16 @@
 # services/file_matching.py
 import pandas as pd
+from services import logger
 
 
 def match_items(po_file, new_items_file, po_qty_column="Sales Products Qty", upc_column="UPC Code"):
     po_df = pd.read_excel(po_file, sheet_name="Final Customer Price List", skiprows=8)
     new_items_df = pd.read_csv(new_items_file)
+    logger.log(f"Matching items using {po_file} and {new_items_file}")
 
     po_df_filtered = po_df[(po_df[po_qty_column] > 1) & (po_df[upc_column].notnull())]
     po_upc_codes = po_df_filtered[upc_column].astype(str).unique()
     matched_items = new_items_df[new_items_df['BARCOD'].astype(str).isin(po_upc_codes)]
 
+    logger.log("Matched items", matched_items)
     return matched_items

--- a/services/file_processing.py
+++ b/services/file_processing.py
@@ -2,6 +2,7 @@
 import pandas as pd
 from config import paths
 from datetime import datetime
+from services import logger
 
 def list_files_in_directory(directory_path):
     return [f.name for f in directory_path.glob("*.*") if f.is_file()]
@@ -12,16 +13,21 @@ def read_full_price_file(filename):
 
 def read_new_items_file(filename):
     file_path = paths.NEW_ITEMS_DIR / filename
-    return pd.read_csv(file_path)
+    df = pd.read_csv(file_path)
+    logger.log(f"Read new items file {filename}", df)
+    return df
 
 def read_po_file(filename):
     file_path = paths.UPLOADED_PO_DIR / filename
-    return pd.read_excel(file_path)
+    df = pd.read_excel(file_path)
+    logger.log(f"Read PO file {filename}", df)
+    return df
 
 
 def save_matched_items(df, output_filename):
     output_path = paths.NEW_ITEMS_DIR / output_filename
     df.to_csv(output_path, index=False)
+    logger.log(f"Saved matched items to {output_filename}", df)
     return output_path
 
 
@@ -31,4 +37,5 @@ def save_selected_items(df):
     filename = f"NewItems_{timestamp}.csv"
     output_path = paths.NEW_ITEMS_DIR / filename
     df.to_csv(output_path, index=False)
+    logger.log(f"Saved selected items to {filename}", df)
     return output_path

--- a/services/logger.py
+++ b/services/logger.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+import pandas as pd
+from config import config_manager, paths
+
+
+def log(message: str, df: pd.DataFrame | None = None) -> None:
+    """Append a log entry if logging is enabled in the configuration."""
+    config = config_manager.load_config()
+    if not config.get("logging_on"):
+        return
+
+    paths.LOG_DIR.mkdir(parents=True, exist_ok=True)
+    log_file = paths.LOG_DIR / f"{datetime.now().strftime('%Y%m%d')}.txt"
+
+    with open(log_file, "a", encoding="utf-8") as f:
+        timestamp = datetime.now().isoformat()
+        f.write(f"{timestamp} - {message}\n")
+        if isinstance(df, pd.DataFrame):
+            f.write(df.to_string())
+            f.write("\n")


### PR DESCRIPTION
## Summary
- add log path constant
- default `logging_on` config option and checkbox on config page
- create `logger` helper to write DataFrame info
- log file reads and writes
- update README with logging instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6876fc4477ec832d86d3d0c41c9611e8