### PR TITLE
Save matched results to Newfiletemp directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ streamlit run app.py
 - Save the configuration.
 
 4. **Process Orders:**
-- Navigate to the Main Page.
-- Click **Start Matching** to generate matched item files.
+ - Navigate to the Main Page.
+ - Click **Start Matching** to generate matched item files. The files will be saved in the `Newfiletemp` folder.
+ - After selecting rows, click **Create new file** to export them as `PreProcess_NewItems_<timestamp>.csv` in the same folder.
 
 ---

--- a/config/paths.py
+++ b/config/paths.py
@@ -5,5 +5,6 @@ BASE_DIR = Path(r"C:/Users/Public/ItemImport")
 
 FULL_PRICE_DIR = BASE_DIR / "Docs"
 NEW_ITEMS_DIR = BASE_DIR / "New"
+NEW_ITEMS_TEMP_DIR = BASE_DIR / "Newfiletemp"
 UPLOADED_PO_DIR = BASE_DIR / "UploadedPO"
 LOG_DIR = BASE_DIR / "log"

--- a/frontend/main_page.py
+++ b/frontend/main_page.py
@@ -34,7 +34,7 @@ def main_page():
             matched_items = file_matching.match_items(po_path, new_items_path, config["po_qty_column"])
             output_filename = f"matched_{po_filename.replace('.xlsx', '')}.csv"
             file_processing.save_matched_items(matched_items, output_filename)
-            st.success(f"Matched items saved to {output_filename}")
+            st.success(f"Matched items saved to Newfiletemp/{output_filename}")
             matched_list.append(matched_items)
 
         if matched_list:
@@ -55,6 +55,6 @@ def main_page():
             if selected_indices:
                 export_df = matched_df.loc[selected_indices]
                 output_path = file_processing.save_selected_items(export_df)
-                st.success(f"Selected items saved to {output_path.name}")
+                st.success(f"Selected items saved to Newfiletemp/{output_path.name}")
             else:
                 st.warning("No items selected.")

--- a/services/file_processing.py
+++ b/services/file_processing.py
@@ -25,17 +25,20 @@ def read_po_file(filename):
 
 
 def save_matched_items(df, output_filename):
-    output_path = paths.NEW_ITEMS_DIR / output_filename
+    """Save matched items to the temporary New Items directory."""
+    paths.NEW_ITEMS_TEMP_DIR.mkdir(parents=True, exist_ok=True)
+    output_path = paths.NEW_ITEMS_TEMP_DIR / output_filename
     df.to_csv(output_path, index=False)
     logger.log(f"Saved matched items to {output_filename}", df)
     return output_path
 
 
 def save_selected_items(df):
-    """Save selected items to a timestamped file in the New Items directory."""
+    """Save selected items to a timestamped file in the temporary directory."""
+    paths.NEW_ITEMS_TEMP_DIR.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now().strftime("%y%m%d_%H%M%S")
-    filename = f"NewItems_{timestamp}.csv"
-    output_path = paths.NEW_ITEMS_DIR / filename
+    filename = f"PreProcess_NewItems_{timestamp}.csv"
+    output_path = paths.NEW_ITEMS_TEMP_DIR / filename
     df.to_csv(output_path, index=False)
     logger.log(f"Saved selected items to {filename}", df)
     return output_path


### PR DESCRIPTION
## Summary
- direct matched and selected CSV output to `Newfiletemp`
- timestamped export files now named `PreProcess_NewItems_<timestamp>.csv`
- mention the new folder in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687bc55a051c832db6f9118d5bcee4a1