### PR TITLE
Add editable preprocessed file page

### DIFF
--- a/frontend/process_configured_matches.py
+++ b/frontend/process_configured_matches.py
@@ -1,14 +1,26 @@
 # frontend/process_configured_matches.py
-"""Page to process matches based on the saved configuration."""
+"""Page to review and edit preprocessed item files."""
 
 import streamlit as st
-from . import main_page
+from services import file_processing
 
 
 def process_configured_matches_page():
-    """Run the matching process using the saved configuration."""
+    """Display an editable view of a preprocessed file."""
     st.header("Process Configured Matches")
-    st.write(
-        "Use this page after configuring matching to generate files from the configured settings."
-    )
-    main_page.main_page()
+
+    preprocessed_files = file_processing.list_preprocessed_files()
+    if not preprocessed_files:
+        st.info("No PreProcess_NewItems files found in Newfiletemp.")
+        return
+
+    selected_file = st.selectbox("Select Preprocessed File", preprocessed_files)
+    if not selected_file:
+        return
+
+    df = file_processing.read_preprocessed_file(selected_file)
+    edited_df = st.data_editor(df, num_rows="dynamic")
+
+    if st.button("Save Changes"):
+        file_processing.save_preprocessed_file(edited_df, selected_file)
+        st.success(f"Saved changes to {selected_file}")

--- a/services/file_processing.py
+++ b/services/file_processing.py
@@ -7,6 +7,11 @@ from services import logger
 def list_files_in_directory(directory_path):
     return [f.name for f in directory_path.glob("*.*") if f.is_file()]
 
+def list_preprocessed_files():
+    """Return all files starting with ``PreProcess_NewItems`` in the temp directory."""
+    paths.NEW_ITEMS_TEMP_DIR.mkdir(parents=True, exist_ok=True)
+    return [f.name for f in paths.NEW_ITEMS_TEMP_DIR.glob("PreProcess_NewItems*") if f.is_file()]
+
 def read_full_price_file(filename):
     file_path = paths.FULL_PRICE_DIR / filename
     return pd.read_excel(file_path)
@@ -42,3 +47,20 @@ def save_selected_items(df):
     df.to_csv(output_path, index=False)
     logger.log(f"Saved selected items to {filename}", df)
     return output_path
+
+
+def read_preprocessed_file(filename):
+    """Read a preprocessed file from the temporary directory."""
+    file_path = paths.NEW_ITEMS_TEMP_DIR / filename
+    df = pd.read_csv(file_path)
+    logger.log(f"Read preprocessed file {filename}", df)
+    return df
+
+
+def save_preprocessed_file(df, filename):
+    """Overwrite an existing preprocessed file in the temporary directory."""
+    paths.NEW_ITEMS_TEMP_DIR.mkdir(parents=True, exist_ok=True)
+    file_path = paths.NEW_ITEMS_TEMP_DIR / filename
+    df.to_csv(file_path, index=False)
+    logger.log(f"Saved edited preprocessed file {filename}", df)
+    return file_path


### PR DESCRIPTION
## Summary
- list preprocessed files from the temp folder
- allow reading and saving those files
- implement new `Process Configured Matches` page showing editable dataframe

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687bf9a4df8c832da6783962251eace6