### PR TITLE
Update dropdown JSON path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 *.pyc
 .idea/
+JsonFiles/
+Newfiletemp/

--- a/config/paths.py
+++ b/config/paths.py
@@ -1,7 +1,12 @@
 # config/paths.py
 from pathlib import Path
 
+# Base directory for external data storage
 BASE_DIR = Path(r"C:/Users/Public/ItemImport")
+
+# Directory containing the dropdown option JSON files
+# These JSON files live inside the same BASE_DIR used for other inputs.
+JSON_FILES_DIR = BASE_DIR / "JsonFiles"
 
 FULL_PRICE_DIR = BASE_DIR / "Docs"
 NEW_ITEMS_DIR = BASE_DIR / "New"

--- a/services/utils.py
+++ b/services/utils.py
@@ -1,5 +1,7 @@
 # services/utils.py
 from pathlib import Path
+import json
+from typing import List
 
 def clean_filename(filename: str) -> str:
     return filename.replace(" ", "_").replace("(", "").replace(")", "")
@@ -7,3 +9,14 @@ def clean_filename(filename: str) -> str:
 def ensure_directories_exist(paths_list):
     for path in paths_list:
         Path(path).mkdir(parents=True, exist_ok=True)
+
+
+def load_json_codes(json_path: Path, code_key: str) -> List[str]:
+    """Return a list of codes from a JSON file."""
+    if not json_path.exists():
+        return []
+    with open(json_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, dict):
+        data = [data]
+    return [str(item.get(code_key, "")) for item in data if code_key in item]


### PR DESCRIPTION
## Summary
- remove temporary example data files
- ignore JsonFiles and Newfiletemp directories
- read JSON dropdown options from the shared BASE_DIR path

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_687c09ed1330832d9d36da6849c1e44b