### PR TITLE
Fix editable dataframe download in process_configured_matches

### DIFF
--- a/frontend/process_configured_matches.py
+++ b/frontend/process_configured_matches.py
@@ -47,11 +47,13 @@ def process_configured_matches_page():
         ),
     }
 
+    editor_key = f"editor_{selected_file}"
     edited_df = st.data_editor(
         df,
         num_rows="dynamic",
         column_config=column_config,
         use_container_width=True,
+        key=editor_key,
     )
 
     csv_data = edited_df.to_csv(index=False).encode("utf-8")


### PR DESCRIPTION
## Summary
- ensure edits persist before download by storing edited dataframe in session state

## Testing
- `python -m py_compile frontend/process_configured_matches.py`


------
https://chatgpt.com/codex/tasks/task_b_687c35e216cc832d90af2a0c1113ab12