### PR TITLE
Save data editor changes in session state

### DIFF
--- a/frontend/process_configured_matches.py
+++ b/frontend/process_configured_matches.py
@@ -56,10 +56,16 @@ def process_configured_matches_page():
         key=editor_key,
     )
 
-    csv_data = edited_df.to_csv(index=False).encode("utf-8")
+    if edited_df is not None:
+        st.session_state[f"edited_{selected_file}"] = edited_df
+
+    csv_df = st.session_state.get(f"edited_{selected_file}", df)
+    csv_data = csv_df.to_csv(index=False).encode("utf-8")
+
+    st.caption("⚠️ Please press Enter or click outside the cell after editing before downloading.")
     st.download_button(
         "Download CSV",
-        csv_data,
+        data=csv_data,
         file_name=f"updated_{selected_file}",
         mime="text/csv",
     )


### PR DESCRIPTION
## Summary
- persist edits from data editor into `st.session_state`
- use persisted edits when generating CSV downloads
- add a caption reminding users to confirm edits before downloading

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_b_687d172b5bc4832dbd30067b29b4e608