### PR TITLE
Enable wide layout for editing table

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,9 @@ from frontend import (
     process_configured_matches,
 )
 
+# Expand the page layout so wide tables utilize more horizontal space
+st.set_page_config(page_title="Maggys Order App", layout="wide")
+
 st.sidebar.title("Navigation")
 page = st.sidebar.radio(
     "Go to",


### PR DESCRIPTION
## Summary
- show more room by switching to Streamlit's wide page layout

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687d88bf179c832db905b276d340b3e4