### PR TITLE
Update preprocessed naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,13 @@ Maggys Order App is a Streamlit application for matching product orders and prep
 
 - Go to **Pre-process matching** (the main page).
 - Click **Start Matching** to compare the selected files. Matched rows are saved in `Newfiletemp/` with names like `matched_<PO>.csv`.
-- Select any rows you wish to keep and click **Create new file**. A `PreProcess_NewItems_<timestamp>.csv` file will be created in the same folder.
+- Select any rows you wish to keep and click **Create new file**. The output will
+  be saved as `preprocessed_<NewItemsFileName>` in the same folder.
 
 ### 3. Process Configured Matches
 
 - Open the **Process configured matches** page.
-- Pick one of the `PreProcess_NewItems` files.
+- Pick one of the `preprocessed_` files.
 - Edit values directly in the table. Category, subcategory, and account codes are loaded from JSON files in `JsonFiles/`.
  - Click **Save Changes** and then **Save new Files** to write the updated and price files into the `ProcessedNew` folder.
 

--- a/frontend/main_page.py
+++ b/frontend/main_page.py
@@ -54,7 +54,7 @@ def main_page():
         if st.button("Create new file"):
             if selected_indices:
                 export_df = matched_df.loc[selected_indices]
-                output_path = file_processing.save_selected_items(export_df)
+                output_path = file_processing.save_selected_items(export_df, new_items_file)
                 st.success(f"Selected items saved to Newfiletemp/{output_path.name}")
             else:
                 st.warning("No items selected.")

--- a/frontend/process_configured_matches.py
+++ b/frontend/process_configured_matches.py
@@ -12,7 +12,7 @@ def process_configured_matches_page():
 
     preprocessed_files = file_processing.list_preprocessed_files()
     if not preprocessed_files:
-        st.info("No PreProcess_NewItems files found in Newfiletemp.")
+        st.info("No preprocessed files found in Newfiletemp.")
         return
 
     selected_file = st.selectbox("Select Preprocessed File", preprocessed_files)

--- a/services/file_processing.py
+++ b/services/file_processing.py
@@ -8,9 +8,9 @@ def list_files_in_directory(directory_path):
     return [f.name for f in directory_path.glob("*.*") if f.is_file()]
 
 def list_preprocessed_files():
-    """Return all files starting with ``PreProcess_NewItems`` in the temp directory."""
+    """Return all files starting with ``preprocessed_`` in the temp directory."""
     paths.NEW_ITEMS_TEMP_DIR.mkdir(parents=True, exist_ok=True)
-    return [f.name for f in paths.NEW_ITEMS_TEMP_DIR.glob("PreProcess_NewItems*") if f.is_file()]
+    return [f.name for f in paths.NEW_ITEMS_TEMP_DIR.glob("preprocessed_*") if f.is_file()]
 
 def read_full_price_file(filename):
     file_path = paths.FULL_PRICE_DIR / filename
@@ -38,11 +38,10 @@ def save_matched_items(df, output_filename):
     return output_path
 
 
-def save_selected_items(df):
-    """Save selected items to a timestamped file in the temporary directory."""
+def save_selected_items(df, source_filename: str):
+    """Save selected rows using the original filename with ``preprocessed_`` prefix."""
     paths.NEW_ITEMS_TEMP_DIR.mkdir(parents=True, exist_ok=True)
-    timestamp = datetime.now().strftime("%y%m%d_%H%M%S")
-    filename = f"PreProcess_NewItems_{timestamp}.csv"
+    filename = f"preprocessed_{source_filename}"
     output_path = paths.NEW_ITEMS_TEMP_DIR / filename
     df.to_csv(output_path, index=False)
     logger.log(f"Saved selected items to {filename}", df)


### PR DESCRIPTION
## Summary
- produce preprocessed file using source filename
- adjust page to supply filename to save function
- look for `preprocessed_` prefix when listing files
- update docs for new naming

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68802b997e78832dad48d7d7e6d77b3b