### PR TITLE
Add redirect after creating new file

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ page = st.sidebar.radio(
         "Pre-process matching",
         "Process configured matches",
     ],
+    key="current_page",
 )
 
 if page == "Pre-process matching":

--- a/frontend/main_page.py
+++ b/frontend/main_page.py
@@ -4,6 +4,7 @@ from config import config_manager, paths
 from services import file_processing, file_matching
 import pandas as pd
 from datetime import datetime
+import time
 
 def main_page():
     st.header("Process Orders")
@@ -56,5 +57,8 @@ def main_page():
                 export_df = matched_df.loc[selected_indices]
                 output_path = file_processing.save_selected_items(export_df, new_items_file)
                 st.success(f"Selected items saved to Newfiletemp/{output_path.name}")
+                time.sleep(3)
+                st.session_state.current_page = "Process configured matches"
+                st.experimental_rerun()
             else:
                 st.warning("No items selected.")


### PR DESCRIPTION
## Summary
- add Streamlit state key for page selection
- redirect to Process Configured Matches page after creating a file

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6882b4d7a004832db8a25e15d3c19a24