### PR TITLE
Fix rerun call

### DIFF
--- a/frontend/main_page.py
+++ b/frontend/main_page.py
@@ -58,6 +58,6 @@ def main_page():
                 st.success(f"Selected items saved to Newfiletemp/{output_path.name}")
                 time.sleep(3)
                 st.session_state.redirect_to_page = "Process configured matches"
-                st.experimental_rerun()
+                st.rerun()
             else:
                 st.warning("No items selected.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-streamlit
+streamlit>=1.25
 pandas
 openpyxl


### PR DESCRIPTION
## Summary
- use `st.rerun()` instead of deprecated `experimental_rerun`
- pin Streamlit version to `>=1.25`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6882c71ac3c8832db4fdf56934f778a7